### PR TITLE
Allow to specify target class for DBTable annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.1.1
+-----
+
+- Refactored DBTable annotation. Now it allows to specify target class which 
+  allows to split class implementation and annotations.
+
 0.1.0
 -----
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -85,7 +85,8 @@ dynamic example() async {
       'postgres://dart_orm_test:dart_orm_test@localhost:5432/dart_orm_test');
   await postgresqlAdapter.connect();
 
-  ORM.Model.ormAdapter = postgresqlAdapter;
+  ORM.addAdapter('postgres', postgresqlAdapter);
+  ORM.setDefaultAdapter('postgres');
 
   bool migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
@@ -97,7 +98,8 @@ dynamic example() async {
       'mongodb://dart_orm_test:dart_orm_test@127.0.0.1/dart_orm_test');
   await mongoAdapter.connect();
 
-  ORM.Model.ormAdapter = mongoAdapter;
+  ORM.addAdapter('mongo', mongoAdapter);
+  ORM.setDefaultAdapter('mongo');
 
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
@@ -108,7 +110,10 @@ dynamic example() async {
   MySQLDBAdapter mysqlAdapter = new MySQLDBAdapter(
       'mysql://dart_orm_test:dart_orm_test@localhost:3306/dart_orm_test');
   await mysqlAdapter.connect();
-  ORM.Model.ormAdapter = mysqlAdapter;
+
+  ORM.addAdapter('mysql', mysqlAdapter);
+  ORM.setDefaultAdapter('mysql');
+
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 

--- a/lib/dart_orm.dart
+++ b/lib/dart_orm.dart
@@ -7,3 +7,5 @@ export 'src/model.dart';
 export 'src/operations.dart';
 export 'src/sql_types.dart';
 export 'src/sql.dart';
+
+export 'src/orm.dart';

--- a/lib/dart_orm.dart
+++ b/lib/dart_orm.dart
@@ -5,7 +5,6 @@ export 'src/annotations.dart';
 export 'src/migrator.dart';
 export 'src/model.dart';
 export 'src/operations.dart';
+export 'src/orm.dart';
 export 'src/sql_types.dart';
 export 'src/sql.dart';
-
-export 'src/orm.dart';

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -70,15 +70,16 @@ class AnnotationsParser {
         if (metaClassName == 'DBTable') {
           DBTable dbTableAnnotation = (metaInstanceMirror.reflectee as DBTable);
 
-            // if annotation target is not provided then class annotated
-            // with DBTable is a model itself
+          // if annotation target is not provided then class annotated
+          // with DBTable is a model itself
           Table table = AnnotationsParser.constructTable(classMirror);
 
-          if(dbTableAnnotation.annotationTarget == null){
+          if (dbTableAnnotation.annotationTarget == null) {
             ormClasses[modelClassName] = table;
           } else {
             // we have annotation target so let's get that class
-            ClassMirror target = reflectClass(dbTableAnnotation.annotationTarget);
+            ClassMirror target =
+                reflectClass(dbTableAnnotation.annotationTarget);
             ormClasses[MirrorSystem.getName(target.simpleName)] = table;
           }
         }
@@ -138,7 +139,8 @@ class AnnotationsParser {
   }
 
   /// Allows setting [field]'s [value] on provided object instance.
-  static dynamic setPropertyValueForField(Field field, dynamic value, dynamic instance) {
+  static dynamic setPropertyValueForField(
+      Field field, dynamic value, dynamic instance) {
     InstanceMirror mirror = reflect(instance);
     return mirror.setField(field.constructedFromPropertyName, value);
   }

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -8,6 +8,7 @@ import 'adapter.dart';
 import 'annotations.dart';
 import 'model.dart';
 import 'operations.dart';
+import 'orm.dart';
 
 final Logger log = new Logger('Migrator');
 
@@ -22,7 +23,7 @@ class OrmInfoTable extends Model {
 
 class Migrator {
   static Future<bool> migrate() async {
-    DBAdapter adapter = Model.ormAdapter;
+    DBAdapter adapter = getDefaultAdapter();
 
     // we store database schema and its version in
     // addition table called orm_info_table

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -2,7 +2,6 @@ library models;
 
 import 'dart:async';
 import 'dart:mirrors';
-import 'dart:collection';
 
 import 'adapter.dart';
 import 'annotations.dart';
@@ -63,9 +62,7 @@ class Model {
    *
    * Throws [Exception] if model instance has not-null primary key.
    */
-  Future insert() {
-    return orm.insert(this);
-  }
+  Future insert() => orm.insert(this);
 
   /**
    * Updates this model instance data on database.
@@ -73,9 +70,7 @@ class Model {
    *
    * Throws [Exception] if this model instance is null.
    */
-  Future update() {
-    return orm.update(this);
-  }
+  Future update() => orm.update(this);
 
   /**
    * Deletes this model instance data on database.
@@ -83,9 +78,7 @@ class Model {
    *
    * Throws [Exception] if this model instance is null.
    */
-  Future delete() async {
-    return orm.delete(this);
-  }
+  Future delete() => orm.delete(this);
 
   Future<bool> save() async {
     var primaryKeyValue = this.getPrimaryKeyValue();
@@ -125,7 +118,7 @@ class FindBase extends Select {
     }
   }
 
-  static Future<dynamic> _executeFindOne(Type modelType, Select sql) async {
+  static Future _executeFindOne(Type modelType, Select sql) async {
     List<Model> foundModels = await _executeFind(modelType, sql);
     if (foundModels.length > 0) {
       return foundModels.last;
@@ -134,8 +127,7 @@ class FindBase extends Select {
     }
   }
 
-  static Future<List<dynamic>> _executeFind(
-      Type modelType, Select selectSql) async {
+  static Future<List> _executeFind(Type modelType, Select selectSql) async {
     Table modelTable = AnnotationsParser.getTableForType(modelType);
     ClassMirror modelMirror = reflectClass(modelType);
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -136,7 +136,6 @@ class FindBase extends Select {
 
   static Future<List<dynamic>> _executeFind(
       Type modelType, Select selectSql) async {
-
     Table modelTable = AnnotationsParser.getTableForType(modelType);
     ClassMirror modelMirror = reflectClass(modelType);
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -3,24 +3,16 @@ library models;
 import 'dart:async';
 import 'dart:mirrors';
 
-import 'adapter.dart';
 import 'annotations.dart';
 import 'operations.dart';
 import 'orm.dart' as orm;
 
 class Model {
   Table _tableDefinition;
-  static DBAdapter _sAdapter;
 
   Model() {
     _tableDefinition = AnnotationsParser.getTableForInstance(this);
   }
-
-  static void set ormAdapter(DBAdapter adapter) {
-    _sAdapter = adapter;
-  }
-
-  static DBAdapter get ormAdapter => _sAdapter;
 
   /**
    * Returns DBFieldSQL instance
@@ -133,7 +125,7 @@ class FindBase extends Select {
 
     List<dynamic> foundInstances = new List<dynamic>();
 
-    var rows = await Model.ormAdapter.select(selectSql);
+    var rows = await orm.getDefaultAdapter().select(selectSql);
     for (Map<String, dynamic> row in rows) {
       InstanceMirror newInstance =
           modelMirror.newInstance(new Symbol(''), [], new Map());

--- a/lib/src/orm.dart
+++ b/lib/src/orm.dart
@@ -10,19 +10,39 @@ import 'annotations.dart';
 import 'operations.dart';
 
 /// List of all available adapters.
-LinkedHashMap<String, DBAdapter> adapters =
+final LinkedHashMap<String, DBAdapter> _adapters =
     new LinkedHashMap<String, DBAdapter>();
 
 String _defaultAdapter = null;
 
+/// Adds database adapter that could be used by orm.
+void addAdapter(String adapterName, DBAdapter adapter) {
+  if (_adapters.containsKey(adapterName)) {
+    throw new Exception('Adapter $adapterName already exists.');
+  }
+
+  _adapters[adapterName] = adapter;
+}
+
 /// Set default adapter that will be used for all models.
+/// Throws exception if there are no adapters configured.
 void setDefaultAdapter(String adapterName) {
+  if (!_adapters.containsKey(adapterName)) {
+    throw new Exception('Adapter $adapterName does not exists.');
+  }
+
   _defaultAdapter = adapterName;
 }
 
 /// Returns default adapter
+/// Throws exception if there are no adapters configured.
 DBAdapter getDefaultAdapter() {
-  return adapters[_defaultAdapter];
+  if (_adapters.length == 0) {
+    throw new Exception(
+        'ORM has no adapters. Add one with addAdapter(adapterName, adapter)');
+  }
+
+  return _adapters[_defaultAdapter];
 }
 
 /// Returns primary key value for [model] instance.

--- a/lib/src/orm.dart
+++ b/lib/src/orm.dart
@@ -1,0 +1,149 @@
+library dart_orm.orm;
+
+import 'dart:async';
+
+import 'dart:collection';
+import 'operations.dart';
+import 'annotations.dart';
+import 'adapter.dart';
+
+LinkedHashMap<String, DBAdapter> adapters =
+    new LinkedHashMap<String, DBAdapter>();
+
+String _defaultAdapter = null;
+void setDefaultAdapter(String adapterName) {
+  _defaultAdapter = adapterName;
+}
+
+DBAdapter getDefaultAdapter() {
+  return adapters[_defaultAdapter];
+}
+
+/// Returns primary key value for [model] instance.
+/// [model] could be any object which class is annotated with DB* annotations.
+dynamic getPrimaryKeyValue(dynamic model) {
+  Table table = AnnotationsParser.getTableForInstance(model);
+
+  if (table == null) {
+    throw new Exception(
+        'Provided class instance does not have DBTable annotation.');
+  }
+
+  Field field = table.getPrimaryKeyField();
+  if (field != null) {
+    var instanceFieldValue =
+        AnnotationsParser.getPropertyValueForField(field, model);
+    return instanceFieldValue;
+  }
+
+  return null;
+}
+
+void setPrimaryKeyValue(dynamic model, dynamic value) {
+  Table table = AnnotationsParser.getTableForInstance(model);
+
+  if (table == null) {
+    throw new Exception(
+        'Provided class instance does not have DBTable annotation.');
+  }
+
+  Field field = table.getPrimaryKeyField();
+  if (field != null) {
+    AnnotationsParser.setPropertyValueForField(field, value, model);
+  } else {
+    throw new Exception(
+        'Provided class instance does not have DBFieldPrimaryKey annotation.');
+  }
+}
+
+/// Inserts [model] instance to database.
+/// Primary key should be empty.
+///
+/// [model] class must have orm annotations.
+Future insert(dynamic model, [DBAdapter adapter = null]) async {
+  var primaryKeyValue = getPrimaryKeyValue(model);
+  if (primaryKeyValue != null) {
+    throw new Exception('insert() should not be called' +
+        'on instances with not-null primary key value, use update() instead.');
+  }
+
+  Table table = AnnotationsParser.getTableForInstance(model);
+  Insert insert = new Insert(table);
+
+  for (Field field in table.fields) {
+    if (!field.isPrimaryKey) {
+      insert.value(field.fieldName,
+          AnnotationsParser.getPropertyValueForField(field, model));
+    }
+  }
+
+  if (adapter == null) {
+    adapter = getDefaultAdapter();
+  }
+
+  var newRecordId = await adapter.insert(insert);
+  if (table.getPrimaryKeyField() != null) {
+    setPrimaryKeyValue(model, newRecordId);
+  }
+
+  return newRecordId;
+}
+
+/// Updates [model] instance in database.
+/// Primary key should not be empty.
+///
+/// [model] class must have orm annotations.
+Future update(dynamic model, [DBAdapter adapter = null]) async {
+  var primaryKeyValue = getPrimaryKeyValue(model);
+  if (primaryKeyValue == null) {
+    throw new Exception('update() should not be called' +
+        'on instances with null primary key value, use insert() instead.');
+  }
+
+  Table table = AnnotationsParser.getTableForInstance(model);
+  Update update = new Update(table);
+
+  for (Field field in table.fields) {
+    var value = AnnotationsParser.getPropertyValueForField(field, model);
+    if (field.isPrimaryKey) {
+      update.where(new Equals(field.fieldName, value));
+    } else {
+      update.set(field.fieldName, value);
+    }
+  }
+
+  if (adapter == null) {
+    adapter = getDefaultAdapter();
+  }
+
+  var updateResult = await adapter.update(update);
+  return updateResult;
+}
+
+/// Deletes [model] instance from database.
+/// Primary key should not be empty.
+///
+/// [model] class must have orm annotations.
+Future delete(dynamic model, [DBAdapter adapter = null]) async {
+  var primaryKeyValue = getPrimaryKeyValue(model);
+  if (primaryKeyValue == null) {
+    throw new Exception('delete() should not be called' +
+        'on instances with null primary key value.');
+  }
+
+  Table table = AnnotationsParser.getTableForInstance(model);
+  Delete delete = new Delete(table);
+
+  Field field = table.getPrimaryKeyField();
+  if (field != null) {
+    var value = AnnotationsParser.getPropertyValueForField(field, model);
+    delete.where(new Equals(field.fieldName, value));
+  }
+
+  if (adapter == null) {
+    adapter = getDefaultAdapter();
+  }
+
+  var deleteResult = await adapter.delete(delete);
+  return deleteResult;
+}

--- a/lib/src/orm.dart
+++ b/lib/src/orm.dart
@@ -1,20 +1,26 @@
+/// This library contains all common methods for orm like insert/update/delete.
+/// It's responsible for storing list of available adapters.
 library dart_orm.orm;
 
 import 'dart:async';
-
 import 'dart:collection';
-import 'operations.dart';
-import 'annotations.dart';
-import 'adapter.dart';
 
+import 'adapter.dart';
+import 'annotations.dart';
+import 'operations.dart';
+
+/// List of all available adapters.
 LinkedHashMap<String, DBAdapter> adapters =
     new LinkedHashMap<String, DBAdapter>();
 
 String _defaultAdapter = null;
+
+/// Set default adapter that will be used for all models.
 void setDefaultAdapter(String adapterName) {
   _defaultAdapter = adapterName;
 }
 
+/// Returns default adapter
 DBAdapter getDefaultAdapter() {
   return adapters[_defaultAdapter];
 }
@@ -39,6 +45,7 @@ dynamic getPrimaryKeyValue(dynamic model) {
   return null;
 }
 
+/// Allows to set primary key [value] for [model] instance.
 void setPrimaryKeyValue(dynamic model, dynamic value) {
   Table table = AnnotationsParser.getTableForInstance(model);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_orm
-version: 0.1.0-dev
+version: 0.1.1
 description: >
   Easy-to-use and easy-to-setup database ORM for dart.
 author: Ustimenko Sergey <ustims@gmail.com>

--- a/test/integration/integration_tests.dart
+++ b/test/integration/integration_tests.dart
@@ -7,6 +7,8 @@ import 'package:dart_orm_adapter_postgresql/dart_orm_adapter_postgresql.dart';
 import 'package:dart_orm_adapter_mongodb/dart_orm_adapter_mongodb.dart';
 import 'package:dart_orm_adapter_mysql/dart_orm_adapter_mysql.dart';
 
+import 'separate_annotations.dart';
+
 @ORM.DBTable('users')
 class User extends ORM.Model {
   @ORM.DBField()
@@ -163,6 +165,9 @@ allTests() {
   test('DateTime', () async {
     await dateTimeTestCase();
   });
+  test('SeparateAnnotations', () async {
+    await testSeparateAnnotations();
+  });
 }
 
 Future runIntegrationTests() async {
@@ -174,21 +179,27 @@ Future runIntegrationTests() async {
   PostgresqlDBAdapter postgresqlAdapter = new PostgresqlDBAdapter(
       'postgres://dart_orm_test:dart_orm_test@localhost:5432/dart_orm_test');
   await postgresqlAdapter.connect();
+  ORM.adapters['postgresql'] = postgresqlAdapter;
   ORM.Model.ormAdapter = postgresqlAdapter;
+  ORM.setDefaultAdapter('postgresql');
   bool migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
   MongoDBAdapter mongoAdapter = new MongoDBAdapter(
       'mongodb://dart_orm_test:dart_orm_test@127.0.0.1/dart_orm_test');
   await mongoAdapter.connect();
+  ORM.adapters['mongodb'] = mongoAdapter;
   ORM.Model.ormAdapter = mongoAdapter;
+  ORM.setDefaultAdapter('mongodb');
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
   MySQLDBAdapter mysqlAdapter = new MySQLDBAdapter(
       'mysql://dart_orm_test:dart_orm_test@localhost:3306/dart_orm_test');
   await mysqlAdapter.connect();
+  ORM.adapters['mysql'] = mysqlAdapter;
   ORM.Model.ormAdapter = mysqlAdapter;
+  ORM.setDefaultAdapter('mysql');
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
@@ -196,6 +207,7 @@ Future runIntegrationTests() async {
     group('PostgreSQL ->', () {
       setUp(() {
         ORM.Model.ormAdapter = postgresqlAdapter;
+        ORM.setDefaultAdapter('postgresql');
       });
 
       allTests();
@@ -204,6 +216,7 @@ Future runIntegrationTests() async {
     group('MySQL ->', () {
       setUp(() {
         ORM.Model.ormAdapter = mysqlAdapter;
+        ORM.setDefaultAdapter('mysql');
       });
 
       allTests();
@@ -212,6 +225,7 @@ Future runIntegrationTests() async {
     group('MongoDB ->', () {
       setUp(() {
         ORM.Model.ormAdapter = mongoAdapter;
+        ORM.setDefaultAdapter('mongodb');
       });
 
       allTests();

--- a/test/integration/integration_tests.dart
+++ b/test/integration/integration_tests.dart
@@ -179,34 +179,38 @@ Future runIntegrationTests() async {
   PostgresqlDBAdapter postgresqlAdapter = new PostgresqlDBAdapter(
       'postgres://dart_orm_test:dart_orm_test@localhost:5432/dart_orm_test');
   await postgresqlAdapter.connect();
-  ORM.adapters['postgresql'] = postgresqlAdapter;
-  ORM.Model.ormAdapter = postgresqlAdapter;
+
+  ORM.addAdapter('postgresql', postgresqlAdapter);
   ORM.setDefaultAdapter('postgresql');
+
   bool migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
   MongoDBAdapter mongoAdapter = new MongoDBAdapter(
       'mongodb://dart_orm_test:dart_orm_test@127.0.0.1/dart_orm_test');
   await mongoAdapter.connect();
-  ORM.adapters['mongodb'] = mongoAdapter;
-  ORM.Model.ormAdapter = mongoAdapter;
+
+  ORM.addAdapter('mongodb', mongoAdapter);
   ORM.setDefaultAdapter('mongodb');
+
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
   MySQLDBAdapter mysqlAdapter = new MySQLDBAdapter(
       'mysql://dart_orm_test:dart_orm_test@localhost:3306/dart_orm_test');
   await mysqlAdapter.connect();
-  ORM.adapters['mysql'] = mysqlAdapter;
-  ORM.Model.ormAdapter = mysqlAdapter;
+
+  ORM.addAdapter('mysql', mysqlAdapter);
   ORM.setDefaultAdapter('mysql');
+
   migrationResult = await ORM.Migrator.migrate();
   assert(migrationResult);
 
   group('Integration tests:', () {
     group('PostgreSQL ->', () {
       setUp(() {
-        ORM.Model.ormAdapter = postgresqlAdapter;
+        // Set default adapter before running tests so all operations
+        // will be made on postres adapter
         ORM.setDefaultAdapter('postgresql');
       });
 
@@ -215,7 +219,8 @@ Future runIntegrationTests() async {
 
     group('MySQL ->', () {
       setUp(() {
-        ORM.Model.ormAdapter = mysqlAdapter;
+        // Set default adapter before running tests so all operations
+        // will be made on mysql adapter
         ORM.setDefaultAdapter('mysql');
       });
 
@@ -224,7 +229,8 @@ Future runIntegrationTests() async {
 
     group('MongoDB ->', () {
       setUp(() {
-        ORM.Model.ormAdapter = mongoAdapter;
+        // Set default adapter before running tests so all operations
+        // will be made on mongo adapter
         ORM.setDefaultAdapter('mongodb');
       });
 

--- a/test/integration/separate_annotations.dart
+++ b/test/integration/separate_annotations.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'package:unittest/unittest.dart';
+
+import 'package:dart_orm/dart_orm.dart' as ORM;
+
+class Comment {
+  int id;
+  String text;
+
+  getText() {
+    return text;
+  }
+}
+
+@ORM.DBTable('comments', Comment)
+class DBCommentMap {
+  @ORM.DBField()
+  @ORM.DBFieldPrimaryKey()
+  int id;
+
+  @ORM.DBField()
+  String text;
+}
+
+Future testSeparateAnnotations() async {
+  Comment comment = new Comment();
+  comment.text = 'Comment text';
+
+  int commentId = await ORM.insert(comment);
+  expect(commentId, 1);
+
+  comment = new Comment();
+  comment.text = 'Another text';
+
+  commentId = await ORM.insert(comment);
+  expect(commentId, 2);
+
+  ORM.FindOne f = new ORM.FindOne(Comment)
+    ..whereEquals('id', 1);
+
+  Comment commentFromDb = await f.execute();
+  expect(commentFromDb.text, 'Comment text');
+  expect(commentFromDb.getText(), 'Comment text');
+}


### PR DESCRIPTION
Dart classes are often used on both client/server side. 
This should allow to have annotations only in server files and leave models clean.

@kevmoo Could you take a look at this?

#10 